### PR TITLE
Add support for custom Trusted CAs

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ docker ... -e IPAM_DATABASE_PASS_FILE=/run/secrets/ipam_database_password
 | **IPAM_BASE**                | "/"                     |        ✅ ❌       | For proxy/load-balancers. Path to access phpipam in site URL, http:/url/BASE/                   |
 | **IPAM_GMAPS_API_KEY** 📂    | ""                      |        ✅ ❌       | Google Maps and Geocode API Key. (Removed in v1.5.0, replaced by OpenStreetMap)                 |
 | **SCAN_INTERVAL**            | "1h"                    |        ❌ ✅       | Network discovery job interval = 5m,10m,15m,30m,1h,2h,4h,6h,12h                                 |
+| **CUSTOM_CA**            | false                    |        ✅ ❌       | Mount a volume to /ca-certs and place all the .crt files for the CAs that need to be trusted by the system. |
 
 ### In Container config.php
 

--- a/dockerfiles/phpipam-base/Dockerfile
+++ b/dockerfiles/phpipam-base/Dockerfile
@@ -10,3 +10,5 @@ RUN apk upgrade --no-cache \
        apache2 apache2-ssl php-apache2
 
 COPY root/ /
+
+RUN mkdir /ca_certs

--- a/dockerfiles/phpipam-base/root/add_trusted_ca
+++ b/dockerfiles/phpipam-base/root/add_trusted_ca
@@ -1,0 +1,8 @@
+#!/bin/ash
+
+if [ $CUSTOM_CA == "true" ]; then
+  echo "Info: Add custom Certificate Authorities set to 'true'. Appending .crt files from /ca-certs to /etc/ssl/certs/ca-certificates.crt"
+     for file in /ca-certs/*.crt; do
+        cat $file >> /etc/ssl/certs/ca-certificates.crt
+    done
+fi

--- a/dockerfiles/phpipam-base/root/start_apache2
+++ b/dockerfiles/phpipam-base/root/start_apache2
@@ -1,6 +1,7 @@
 #!/bin/ash
 
 /set_timezone
+/add_trusted_ca
 if [ $? -ne 0 ]
 then
   exit 1


### PR DESCRIPTION
I have the need to use only LDAPs signed by our own CA. When migrating from VM to Docker I've decided to adjust the image to support adding custom Certificate Authorities to the base system so that php-openssl will trust those.

Hope it's ok, feel free to change anything.